### PR TITLE
Switch to w5 and adding search method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ Get the latest articles on this section:
  - 'Новая иллюзия: круги, раскрашенные в четыре разных цвета (на самом деле нет)'
 ```
 
+Search articles by key words:
+
+```python
+# English version:
+
+>>> for article in meduza.search('Indigenous', n=3, lang='en'):
+...     print(f" - '{article['title']}'")
+ - 'Indigenous scholar commits self-immolation in Ural city to protest language death'
+ - '‘This is the land of our ancestors’'
+ - 'Trial by fire'
+
+
+# Russian version:
+
+>>> for article in meduza.search('языка коренного', n=3, lang='ru'):
+...     print(f" - '{article['title']}'")
+ - 'Острова Кука собрались сменить название'
+ - 'Последний аргумент в длинном споре'
+ - 'При пожаре в Национальном музее Бразилии погиб архив языков коренных народов. Некоторые из них больше никто не знает'
+ ```
+ 
 You can find available tags and sections in constants:
 
 ```python
@@ -62,3 +83,4 @@ You can find available tags and sections in constants:
 >>> meduza.RU_TAGS
 ('новости', 'истории', 'разбор', 'шапито', 'игры', 'подкасты', 'партнерский материал')
 ```
+ 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_long_description() -> str:
 
 setup(
     name='meduza',    
-    version='18.12.1',
+    version='20.7.1',
     license='MIT',
     author='Dima Koskin',
     author_email='dmksknn@gmail.com',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -61,3 +61,9 @@ class TestPublicAPI(unittest.TestCase):
             meduza.section("news", 24)
         with self.assertRaises(TypeError):
             meduza.tag("новости", 24)
+
+    def test_search(self):
+        sobaka = meduza.search("собака", n=24, lang="ru")
+        self.assertTrue(isgenerator(sobaka))
+        sobaka_list = list(sobaka)
+        self.assertEqual(len(sobaka_list), 24)


### PR DESCRIPTION
Hello Dima,

I updated the code to use w5.

I also added functionality to use search terms on Meduza's api.
An example url is 'https://meduza.io/api/w5/search?term=коренного&page=0&per_page=24&locale=ru'
This follows the same format as searching by section, only instead of 'chrono' uses 'term'.

Let me know if it looks good.

Thanks,
Aaron